### PR TITLE
scylla_util.sh: fix the exec user if is_nonroot

### DIFF
--- a/dist/common/supervisor/scylla_util.sh
+++ b/dist/common/supervisor/scylla_util.sh
@@ -12,9 +12,9 @@ is_privileged() {
 
 execsudo() {
     if is_nonroot; then
-        exec "$@"
-    else
         exec sudo -u scylla -g scylla "$@"
+    else
+        exec "$@"
     fi
 }
 scriptsdir="$scylladir/scripts"


### PR DESCRIPTION
Hi, my Scylla cluster stopped working due to permission denied on the filesystem after I upgraded it to 4.6.0 docker image.

It seems to me that this `scylla_util.sh` file causing the permission denied problem since it now defaults to using `scylla` user instead of the `root`. But the code looks wired:
```sh
if is_nonroot; then
  exec "$@"
else
  exec sudo -u scylla -g scylla "$@"
fi
```

I think it should be:
```sh
if is_nonroot; then
  exec sudo -u scylla -g scylla "$@"
else
  exec "$@"
fi
```

Could someone clarify this?